### PR TITLE
Implement forecast flip view

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
                 </ul>
             </nav>
             <div id="card" class="weather">
+                <div class="front">
                 <svg id="inner">
                     <defs>
                         <path id="leaf" d="M41.9,56.3l0.1-2.5c0,0,4.6-1.2,5.6-2.2c1-1,3.6-13,12-15.6c9.7-3.1,19.9-2,26.1-2.1c2.7,0-10,23.9-20.5,25 c-7.5,0.8-17.2-5.1-17.2-5.1L41.9,56.3z"/>
@@ -83,7 +84,12 @@
                         <div id="date">Lädt...</div>
                         <div id="summary">Lädt...</div>
                     </div>
+                </div> <!-- details -->
+                </div> <!-- end front -->
+                <div class="back" id="forecast">
+                    <ul id="forecast-list"></ul>
                 </div>
+                <button id="flip-forecast" title="Vorhersage anzeigen"><i class="wi wi-direction-down-right"></i></button>
             </div>
             <svg id="outer"></svg>
         </div>

--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ body {
     background: #eee;
     background: linear-gradient(240deg, rgba(150, 50, 50, 0.3), rgba(0, 0, 200, 0));
     box-sizing: border-box;
+    perspective: 1000px;
 }
 
 /* *** NEU: Stile für Überschrift *** */
@@ -104,6 +105,31 @@ body {
 #geolocation-button:hover svg {
     fill: #333; /* Dunklere Farbe bei Hover */
 }
+
+/* Button zum Umschalten der Vorhersageansicht */
+#card #flip-forecast {
+    position: absolute;
+    bottom: 12px;
+    right: 12px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #4a90e2;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+}
+#card #flip-forecast i {
+    pointer-events: none;
+    font-size: 20px;
+}
+#card #flip-forecast:hover {
+    background-color: #357abd;
+}
 /* Alte Hover-Regel entfernt/auskommentiert:
 #geolocation-button:hover {
     background-color: #d0d0d0;
@@ -175,6 +201,8 @@ nav li a.active {
     margin: 20px;
     border-radius: 5px;
     position: relative;
+    transform-style: preserve-3d;
+    transition: transform 0.6s;
 }
 #card .details {
     position: absolute;
@@ -223,6 +251,26 @@ nav li a.active {
     line-height: 30px;
     vertical-align: top;
     margin-left: 5px;
+}
+
+#card .front,
+#card .back {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+}
+#card .back {
+    transform: rotateY(180deg);
+    background: rgba(255,255,255,0.9);
+    overflow-y: auto;
+    padding: 20px;
+    box-sizing: border-box;
+}
+#card.flipped {
+    transform: rotateY(180deg);
 }
 
 /* Basis-Wetter-Stil */


### PR DESCRIPTION
## Summary
- add button for forecast flip and wrap card front/back
- style flip button and card flip behavior
- implement forecast API fetch and flip logic
- fix flip button position and design

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b509fdd48330ad44de693d4b11c8