### PR TITLE
Disable debug weather switcher UI by default

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,6 +79,7 @@ var weather = [
 	{ type: 'sun', name: 'Sonnig'},
 	{ type: 'cloudy', name: 'Bewölkt'}
 ];
+var ENABLE_DEBUG_WEATHER_SWITCHER = false;
 var currentWeather = null;
 var currentLat = 51.51; // Default Dortmund
 var currentLon = 7.46;  // Default Dortmund
@@ -162,7 +163,10 @@ function init() {
     console.log("0. init() called"); // Log 0
     onResize();
     console.log("0a. onResize finished.");
-    for(var i = 0; i < weather.length; i++) { var w = weather[i]; var b = $('#button-' + w.type); if (b.length === 0) { console.warn("Button not found for:", w.type); continue; } w.button = b; b.bind('click', w, changeWeather); }
+    $('nav').toggle(ENABLE_DEBUG_WEATHER_SWITCHER);
+    if (ENABLE_DEBUG_WEATHER_SWITCHER) {
+        for(var i = 0; i < weather.length; i++) { var w = weather[i]; var b = $('#button-' + w.type); if (b.length === 0) { console.warn("Button not found for:", w.type); continue; } w.button = b; b.bind('click', w, changeWeather); }
+    }
     console.log("0b. Buttons bound.");
     for(var i = 0; i < clouds.length; i++) { if (clouds[i] && clouds[i].group) { clouds[i].offset = Math.random() * sizes.card.width; drawCloud(clouds[i], i); gsap.set(clouds[i].group.node, { x: clouds[i].offset }); } else { console.warn("Cloud group missing for index:", i); } }
     console.log("0c. Clouds drawn.");


### PR DESCRIPTION
### Motivation
- Hide the manual debug weather nav used for toggling animations in normal usage while still allowing it to be re-enabled for debugging via a flag.

### Description
- Introduced `ENABLE_DEBUG_WEATHER_SWITCHER = false` and updated `init()` to call `$('nav').toggle(ENABLE_DEBUG_WEATHER_SWITCHER)` and to bind the debug weather buttons only when the flag is `true`.

### Testing
- Ran `node --check script.js` which completed without errors, started a local server via `python3 -m http.server 4173` and captured a Playwright screenshot to verify the debug nav is hidden (all checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a2d26ea648331afa372f9fcae6688)